### PR TITLE
Fixed sequence type error when iceServers is not defined

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -2131,6 +2131,9 @@ function shimRTCIceServerUrls(window) {
         }
       }
       pcConfig.iceServers = newIceServers;
+    } else if (pcConfig) {
+      //This handles the case where the user explicitly configured no iceServers so pcConfig.iceServers is null
+      pcConfig.iceServers = []; //we ensure the pcConfig.iceServers is a sequence type
     }
     return new OrigPeerConnection(pcConfig, pcConstraints);
   };

--- a/src/tinyMEDIA/src/tmedia_session_jsep.js
+++ b/src/tinyMEDIA/src/tmedia_session_jsep.js
@@ -791,6 +791,10 @@ tmedia_session_jsep01.prototype.__get_lo = function () {
             this.ao_webrtc_rtcconfiguration
         );
 
+        if(!o_RTCConfiguration.iceServers) {
+            //we must always provide a "sequence type" for our ice servers when calling RTCPeerConnection
+            o_RTCConfiguration.iceServers = [];
+        }
         this.o_pc = new window.RTCPeerConnection(o_RTCConfiguration, o_constraints);
 
         this.o_pc.onicecandidate = tmedia_session_jsep01.mozThis ? tmedia_session_jsep01.onIceCandidate : function (o_event) { tmedia_session_jsep01.onIceCandidate(o_event, This); };


### PR DESCRIPTION
When the user uses expert mode and configured [] or empty string as the `iceServers` Chrome, Firefox and Safari,would error because "null" is not the expected sequence type when calling `window.RTCPeerConnection`.

This PR fixes this by checking `iceServers` field for null before the call to `window.RTCPeerConnection` and setting it to [].